### PR TITLE
fix: changing semantic release bot 

### DIFF
--- a/.github/workflows/versioning-workflow.yml
+++ b/.github/workflows/versioning-workflow.yml
@@ -5,7 +5,6 @@ on:
       - main
       - staging
       - development
-      - semantic-release
     
 
 permissions:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,5 +1,5 @@
 {
-  "branches": ["main", {"name": "development", "prerelease": true}, {"name": "staging", "prerelease": true}, {"name": "semantic-release", "prerelease": true}],
+  "branches": ["main", {"name": "development", "prerelease": true}, {"name": "staging", "prerelease": true}],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Changing semantic release bot to my account to prevent issues with Eclipse certificates and also to make the bypass PR rule easier