### PR TITLE
Fix aas-server endpoint configuration and startup dependencies

### DIFF
--- a/.env
+++ b/.env
@@ -20,4 +20,4 @@ AAS_SERVER_PORT=50010
 AAS_INDEX=mysql://aas-node:60PYRe6Vd8C99u4n@aasportal-index:3306
 USER_STORAGE=mongodb://aas-node:bObXJWW6e8Nh78YF@aasportal-users:27017/aasportal-users
 TEMPLATE_STORAGE=http://aas-node:5w0vmrkzrwDIDyZs@aasportal-cloud:8080/templates
-ENDPOINTS=["http://aas-node:50010/api/v3/?name=AAS%20Server"]
+ENDPOINTS=["http://aas-server:50010/api/v3/?name=AAS%20Server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,12 @@ services:
       dockerfile: ./Dockerfile.aas-server
       args:
         - NODE_IMAGE=${NODE_IMAGE}
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:50010/api/v3/shells"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
     volumes:
       - aas-server:/data
     environment:
@@ -93,6 +99,13 @@ services:
       dockerfile: ./Dockerfile.aas-node
       args:
         - NODE_IMAGE=${NODE_IMAGE}
+    depends_on:
+      aas-server:
+        condition: service_healthy
+      aasportal-index:
+        condition: service_healthy
+      aasportal-users:
+        condition: service_started
     environment:
       - AAS_NODE_PORT=${AAS_NODE_PORT}
       - USER_STORAGE=${USER_STORAGE}


### PR DESCRIPTION
## Problem
On fresh startup, no AAS were visible in the portal because:
1. The `.env` file incorrectly pointed to `aas-node:50010` instead of `aas-server:50010`
2. There was a race condition where `aas-node` tried to connect to `aas-server` before it was ready

## Solution
- Fix ENDPOINTS in `.env`: use `aas-server` instead of `aas-node`
- Add healthcheck to `aas-server` to ensure it's ready before other services depend on it
- Add `depends_on` with health conditions to `aas-node` to wait for:
  - `aas-server` (healthy)
  - `aasportal-index` (healthy)
  - `aasportal-users` (started)

## Testing
Tested with clean volumes (`podman compose down -v`) and rebuild:
- ✅ Endpoint correctly registered as `http://aas-server:50010/api/v3/`
- ✅ 31 AAS loaded successfully on first startup
- ✅ No connection errors in logs
- ✅ Frontend accessible and functional

This ensures AAS are loaded correctly on first startup without manual intervention.