### PR TITLE
docs: add required JWT_SECRET to Kubernetes deployment examples

### DIFF
--- a/k8s-deployment-example.yaml
+++ b/k8s-deployment-example.yaml
@@ -1,0 +1,85 @@
+---
+# Example Kubernetes Deployment for AASPortal
+# This deployment includes all required configuration for authentication and sample data
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aas-portal
+  namespace: aasportal
+  labels:
+    app: aas-portal
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aas-portal
+  template:
+    metadata:
+      labels:
+        app: aas-portal
+    spec:
+      containers:
+      - name: aas-portal
+        image: fraunhoferiosb/aasportal:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        # REQUIRED: JWT secret for user authentication
+        - name: JWT_SECRET
+          value: "change-this-secret-in-production"
+        # Optional: Initial AAS container endpoints
+        - name: ENDPOINTS
+          value: '["file:///endpoints/samples?name=Samples"]'
+        ports:
+        - containerPort: 80
+          name: http
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aas-portal-service
+  namespace: aasportal
+spec:
+  selector:
+    app: aas-portal
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+  type: ClusterIP
+---
+# For production use, store JWT_SECRET in a Kubernetes Secret:
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: aas-portal-secrets
+#   namespace: aasportal
+# type: Opaque
+# stringData:
+#   JWT_SECRET: "your-super-secret-jwt-key-change-in-production"
+#
+# Then reference it in the deployment:
+#   env:
+#   - name: JWT_SECRET
+#     valueFrom:
+#       secretKeyRef:
+#         name: aas-portal-secrets
+#         key: JWT_SECRET

--- a/read-the-docs/source/kubernetes.md
+++ b/read-the-docs/source/kubernetes.md
@@ -45,6 +45,11 @@ spec:
       containers:
       - name: aas-portal
         image: fraunhoferiosb/aasportal:latest
+        env:
+        - name: JWT_SECRET
+          value: "change-this-secret-in-production"  # REQUIRED for authentication
+        - name: ENDPOINTS
+          value: '["file:///endpoints/samples?name=Samples"]'  # Optional: sample data
         ports:
         - containerPort: 80
           name: http
@@ -89,6 +94,11 @@ Apply the deployment:
 kubectl create namespace aasportal
 kubectl apply -f deployment.yaml
 ```
+
+**Important:** 
+- `JWT_SECRET` is **required** for user authentication (login/register) to work
+- Always use a strong, unique secret in production environments
+- Consider using Kubernetes Secrets instead of plain environment variables (see [Environment Variables](#environment-variables) section)
 
 ## Ingress Configuration
 


### PR DESCRIPTION
- Add JWT_SECRET environment variable to basic deployment example
- Mark JWT_SECRET as REQUIRED for authentication to work
- Add ENDPOINTS example for sample data configuration
- Include security warning about production secrets
- Create k8s-deployment-example.yaml with complete working manifest
- Add guidance on using Kubernetes Secrets for production

Fixes issue where users couldn't login/register after deployment