### PR TITLE
docs: fix version inconsistencies in read-the-docs

### DIFF
--- a/read-the-docs/source/development.md
+++ b/read-the-docs/source/development.md
@@ -542,13 +542,13 @@ npm run lint -ws
 **Multi-stage Dockerfile:**
 ```dockerfile
 # Build stage
-FROM node:22.12.0-alpine AS build
+FROM node:22.16.0-alpine AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --only=production
 
 # Production stage
-FROM node:22.12.0-alpine AS production
+FROM node:22.16.0-alpine AS production
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nodejs -u 1001
 USER nodejs

--- a/read-the-docs/source/workspaces.md
+++ b/read-the-docs/source/workspaces.md
@@ -14,7 +14,7 @@ The following diagram shows the dependencies between workspaces:
 |-----------|---------|------------|--------------|
 | [aas-core](#aas-core) | Shared types and utilities | TypeScript, ESM | `dist/` |
 | [aas-package](#aas-package) | AASX package file handling | TypeScript, JSZip | `dist/` |
-| [aas-portal](#aas-portal) | Frontend application | Angular 20.1.6, NgRx | `dist/browser/` |
+| [aas-portal](#aas-portal) | Frontend application | Angular 20.3.0, NgRx | `dist/browser/` |
 | [aas-node](#aas-node) | Backend API server | Express.js, esbuild | `dist/` |
 | [aas-lib](#aas-lib) | Reusable UI components | Angular Library | `dist/` |
 | [aas-server](#aas-server) | AAS server (IDTA Part 2) | Express.js, TSOA | `dist/` |
@@ -143,7 +143,7 @@ npm run watch -w aas-package         # Watch mode for tests
 **Purpose**: Angular-based frontend application for AAS visualization and management
 
 ### Key Features
-- **Angular 20.1.6**: Latest Angular framework with signals support
+- **Angular 20.3.0**: Latest Angular framework with signals support
 - **NgRx State Management**: Reactive state management pattern
 - **Bootstrap 5 UI**: Responsive design with ng-bootstrap components
 - **Multi-language Support**: i18n with ngx-translate


### PR DESCRIPTION
- Update Node.js from 22.12.0 to 22.16.0 in development.md Dockerfile examples
- Update Angular from 20.1.6 to 20.3.0 in workspaces.md (matches package.json)