### PR TITLE
fix: enable static file serving for aas-browser frontend

### DIFF
--- a/.env
+++ b/.env
@@ -17,6 +17,7 @@ NEXTCLOUD_TRUSTED_DOMAINS=localhost
 NODE_ENV=production
 AAS_NODE_PORT=1337
 AAS_SERVER_PORT=50010
+ENABLE_STATIC_FILES=true
 AAS_INDEX=mysql://aas-node:60PYRe6Vd8C99u4n@aasportal-index:3306
 USER_STORAGE=mongodb://aas-node:bObXJWW6e8Nh78YF@aasportal-users:27017/aasportal-users
 TEMPLATE_STORAGE=http://aas-node:5w0vmrkzrwDIDyZs@aasportal-cloud:8080/templates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - aas-server:/data
     environment:
       - AAS_SERVER_PORT=${AAS_SERVER_PORT}
+      - ENABLE_STATIC_FILES=${ENABLE_STATIC_FILES}
     ports:
       - 50010:50010
 


### PR DESCRIPTION
## Description
Fixes #143

This PR enables the AAS Browser frontend to be accessible at http://localhost:50010/ by enabling static file serving in the aas-server.

## Changes
- Added `ENABLE_STATIC_FILES=true` to the .env file
- Added `ENABLE_STATIC_FILES` environment variable to the aas-server service in docker-compose.yml

## Testing
1. Start services: `podman-compose up -d` or `docker-compose up -d`
2. Wait for aas-server to become healthy
3. Navigate to http://localhost:50010/
4. Verify that the AAS Browser frontend loads correctly

## Impact
- Users can now access the lightweight AAS Browser frontend alongside the API
- No breaking changes - the API endpoints continue to work as before