### PR TITLE
Improve nameplate text readability and contrast

### DIFF
--- a/projects/aas-lib/src/lib/views/nameplate/nameplate.html
+++ b/projects/aas-lib/src/lib/views/nameplate/nameplate.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="row">
-      <div class="col-md-6 bg-primary-subtle text-black p-3 bg-opacity-75">
+      <div class="col-md-6 bg-primary text-white p-3">
         <div class="d-flex flex-row">
             <div>
                 @if (checkNameplateValue("ManufacturerProductDesignation")) {


### PR DESCRIPTION
## Description
Improves the nameplate component's text readability by enhancing the contrast between background and text.

## Changes
- Changed styling from `bg-primary-subtle text-black bg-opacity-75` to `bg-primary text-white`
- Removed opacity effect that was reducing text clarity
- Improved overall accessibility and user experience

## Related Issue
Closes #160

## Testing
- Built and tested locally with podman compose
- Visual inspection confirms improved readability
- No functional changes, purely styling improvement

## Type of Change
- UI/UX Enhancement
- Accessibility Improvement